### PR TITLE
remove @beniwohli and add @basepi to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @beniwohli @tobiasraabe
+* @basepi @tobiasraabe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @basepi @tobiasraabe
+* @beniwohli @tobiasraabe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,5 +45,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - beniwohli
+    - basepi
     - tobiasraabe


### PR DESCRIPTION
I am no longer a maintainer of the upstream `elastic-apm` package. @basepi has the reigns :) 