### PR TITLE
Adapt wrapt dependency to upstream

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 3a8959962b604623209b7a69302cddb4df26eca959a98069e09052e5761e9da4
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script_env: ELASTIC_APM_WRAP_EXTENSIONS=false
   script: {{ PYTHON }} -m pip install . -vv
@@ -25,7 +25,7 @@ requirements:
     - ecs-logging
     - python >=3.6,<4.0
     - urllib3
-    - wrapt >=1.14.1,<1.15.0
+    - wrapt >=1.14.1,!=1.15.0
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This PR aligns the wrapt dependency with upstream again:
https://github.com/elastic/apm-agent-python/blob/6056e241fd8fe7aa5e06450786f3843cf383f3a2/setup.cfg#L42